### PR TITLE
[readme] fix documentation to prevent load errors

### DIFF
--- a/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
@@ -55,7 +55,7 @@ discovery.relabel "specific_pods" {
 
 pyroscope.ebpf "instance" {
     forward_to = [pyroscope.write.endpoint.receiver]
-    targets = discovery.relabel.specific_pods.targets
+    targets = discovery.relabel.specific_pods.output
 }
 
 pyroscope.write "endpoint" {


### PR DESCRIPTION
```
Error: /etc/agent/config.river:61:47: field "targets" does not exist

60 |     forward_to = [pyroscope.write.endpoint.receiver]
61 |     targets = discovery.relabel.specific_pods.targets
   |                                               ^^^^^^^
62 | }
```